### PR TITLE
shell fixup for odd gmake env issue

### DIFF
--- a/cddl/tools.mk
+++ b/cddl/tools.mk
@@ -1,3 +1,4 @@
+SHELL:=/bin/bash
 cddl ?= $(shell command -v cddl)
 ifeq ($(strip $(cddl)),)
   $(error cddl tool not found. To install cddl, run: 'gem install cddl')


### PR DESCRIPTION
force shell to bash in tools check for environment where gmake not picking up /bin/bash